### PR TITLE
Ordenar por custo benefício por tipo ideia #35

### DIFF
--- a/lib/growth_channel/google_ads/views.rb
+++ b/lib/growth_channel/google_ads/views.rb
@@ -1,89 +1,135 @@
+# frozen_string_literal: true
+
 require 'csv'
 
 module GoogleAds
-  
-    class View
-  
-      def initialize(file_path)
-        @file_path = file_path
-      end
-  
-      def total_views_per_video
-        total_per_video = []
-        videos_principais_agrupados.each do |videos_principais_agrupado|
-          id_video_principal = videos_principais_agrupado.first[:id_video_principal]
-          sum_views = videos_principais_agrupado.inject(0) { |sum, hash| sum + hash[:views] }
-  
-          total_per_video.push({id_video_principal: id_video_principal, views: sum_views})
-        end
-        total_per_video
-      end
-      
-      def total_views_video_externo
-        total_per_video = []
-        videos_principais_agrupados_externo.each do |videos_principais_agrupado|
-          id_video_principal = videos_principais_agrupado.first[:id_video_principal]
-          sum_views = videos_principais_agrupado.inject(0) { |sum, hash| sum + hash[:views] }
-  
-          total_per_video.push({id_video_principal: id_video_principal, views: sum_views})
-        end
-        total_per_video
-      end
+  class View
+    def initialize(file_path)
+      @file_path = file_path
+    end
 
-      def get_videos_ideias
-        total_per_video = []
-        group_videos_by_tag('[Ideias]').each do |videos_principais_agrupado|
-          id_video_principal = videos_principais_agrupado.first[:id_video_principal]
-          sum_views = videos_principais_agrupado.inject(0) { |sum, hash| sum + hash[:views] }
+    def total_views_per_video
+      total_per_video = []
+      videos_principais_agrupados.each do |videos_principais_agrupado|
+        id_video_principal = videos_principais_agrupado.first[:id_video_principal]
+        sum_views = videos_principais_agrupado.inject(0) { |sum, hash| sum + hash[:views] }
 
-          total_per_video.push({ id_video_principal: id_video_principal, views: sum_views })
-        end
-        total_per_video
+        total_per_video.push({ id_video_principal: id_video_principal, views: sum_views })
       end
-  
-      private
+      total_per_video
+    end
 
-      # @return [Array_0f_all_videos]
-      def read_per_video
-        reports = CSV.read(@file_path, headers: true)
-        videos_principais = []
-        reports.each do |row|
-          tags_campanha = row['Campanha'].split(' ')
-          id_video = tags_campanha.first
-          tags_campanha.shift
-          id_video_principal = id_video.split('.').first
-          views = row['Visualizações'].to_i
+    def total_views_video_externo
+      total_per_video = []
+      videos_principais_agrupados_externo.each do |videos_principais_agrupado|
+        id_video_principal = videos_principais_agrupado.first[:id_video_principal]
+        sum_views = videos_principais_agrupado.inject(0) { |sum, hash| sum + hash[:views] }
 
-          videos_principais.push({
-                                     id_video: id_video,
-                                     id_video_principal: id_video_principal,
-                                     tags_campanha: tags_campanha,
-                                     views: views
-                                 })
-        end
-        videos_principais
+        total_per_video.push({ id_video_principal: id_video_principal, views: sum_views })
       end
-   
-      def videos_principais_agrupados
-        read_per_video.group_by { |h| h[:id_video_principal] }.values
-      end
-  
-      def videos_principais_agrupados_externo
-        videos_externo = []
-        read_per_video.each do |video|
-          if video[:id_video].split(".").last.to_i > 0
-            videos_externo.push(video)
-          end
-        end
-        return videos_externo.group_by { |h| h[:id_video_principal] }.values
-      end
+      total_per_video
+    end
 
-      def group_videos_by_tag(tag)
-        group = []
-        read_per_video.each do |video|
-          group.push(video) if video[:tags_campanha].include? tag
-        end
-        group.group_by { |h| h[:id_video_principal] }.values
+    def get_videos_ideias
+      total_per_video = []
+      group_videos_by_tag('[Ideias]').each do |videos_principais_agrupado|
+        id_video_principal = videos_principais_agrupado.first[:id_video_principal]
+        sum_views = videos_principais_agrupado.inject(0) { |sum, hash| sum + hash[:views] }
+
+        total_per_video.push({ id_video_principal: id_video_principal, views: sum_views })
       end
+      total_per_video
+    end
+
+    def cost_benefit_per_video
+      group_videos_cost_benefit = []
+      group_main_video_info.each do |video|
+        id_video_principal = video[:id_video_principal]
+        cost_benefit = video[:views] + (video[:watched_25] * 2) + (video[:watched_50] * 4) + (video[:watched_75] * 5) + (video[:watched_100] * 3)
+        cost_benefit /= 15 # soma dos pesos
+        cost_benefit /= video[:cost]
+        cost_benefit = cost_benefit.floor(2)
+        group_videos_cost_benefit.push({ id_video_principal: id_video_principal, cost_benefit: cost_benefit })
+      end
+      group_videos_cost_benefit
+    end
+
+    private
+
+    # @return [Array_0f_all_videos]
+    def read_per_video
+      reports = CSV.read(@file_path, headers: true)
+      videos_principais = []
+      reports.each do |row|
+        tags_campanha = row['Campanha'].split(' ')
+        id_video = tags_campanha.first
+        tags_campanha.shift
+        id_video_principal = id_video.split('.').first
+        views = row['Visualizações'].to_i
+        cost = row['Custo'].sub(',', '.').to_f
+        rdv25 = row['Reprod. do vídeo até 25%'].sub(',', '.').to_f
+        rdv50 = row['Reprod. do vídeo até 50%'].sub(',', '.').to_f
+        rdv75 = row['Reprod. do vídeo até 75%'].sub(',', '.').to_f
+        rdv100 = row['Reprod. do vídeo até 100%'].sub(',', '.').to_f
+
+        videos_principais.push({
+                                 id_video: id_video,
+                                 id_video_principal: id_video_principal,
+                                 tags_campanha: tags_campanha,
+                                 views: views,
+                                 cost: cost,
+                                 watched_25: rdv25,
+                                 watched_50: rdv50,
+                                 watched_75: rdv75,
+                                 watched_100: rdv100
+                               })
+      end
+      videos_principais
+    end
+
+    # @return [Array_of_group_main_video_contains_all_info]
+    def group_main_video_info
+      group_main_video = []
+      videos_principais_agrupados.each do |video|
+        id_video_principal = video.first[:id_video_principal]
+        sum_views = video.inject(0) { |sum, hash| sum + hash[:views] }
+        sum_cost = video.inject(0) { |sum, hash| sum + hash[:cost] }
+        sum_watched_25 = video.inject(0) { |sum, hash| sum + hash[:watched_25] }
+        sum_watched_50 = video.inject(0) { |sum, hash| sum + hash[:watched_50] }
+        sum_watched_75 = video.inject(0) { |sum, hash| sum + hash[:watched_75] }
+        sum_watched_100 = video.inject(0) { |sum, hash| sum + hash[:watched_100] }
+
+        group_main_video.push({
+                                id_video_principal: id_video_principal,
+                                views: sum_views,
+                                cost: sum_cost,
+                                watched_25: sum_watched_25,
+                                watched_50: sum_watched_50,
+                                watched_75: sum_watched_75,
+                                watched_100: sum_watched_100
+                              })
+      end
+      group_main_video
+    end
+
+    def videos_principais_agrupados
+      read_per_video.group_by { |h| h[:id_video_principal] }.values
+    end
+
+    def videos_principais_agrupados_externo
+      videos_externo = []
+      read_per_video.each do |video|
+        videos_externo.push(video) if video[:id_video].split('.').last.to_i.positive?
+      end
+      videos_externo.group_by { |h| h[:id_video_principal] }.values
+    end
+
+    def group_videos_by_tag(tag)
+      group = []
+      read_per_video.each do |video|
+        group.push(video) if video[:tags_campanha].include? tag
+      end
+      group.group_by { |h| h[:id_video_principal] }.values
     end
   end
+end

--- a/spec/google_ads/view_spec.rb
+++ b/spec/google_ads/view_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "GoogleAds::View" do
     it "total_views_video_externo" do
       groups = GoogleAds::View.new('spec/suports/report_adsense_sample.csv').total_views_video_externo
       result = [
-          {id_video_principal: 'v1', views: 411 + 301},
-          {id_video_principal: 'v10', views: 107 + 0 + 37}
+        {id_video_principal: 'v1', views: 411 + 301},
+        {id_video_principal: 'v10', views: 107 + 0 + 37}
       ]
       expect(groups).to match_array(result)
     end
@@ -25,10 +25,20 @@ RSpec.describe "GoogleAds::View" do
     it 'total_views_per_video_ideias' do
       groups = GoogleAds::View.new('spec/suports/report_adsense_sample.csv').get_videos_ideias
       result = [
-          { id_video_principal: 'v1', views: 411 + 301 },
-          { id_video_principal: 'v10', views: 107 + 0 + 37 }
+        { id_video_principal: 'v1', views: 411 + 301 },
+        { id_video_principal: 'v10', views: 107 + 0 + 37 }
       ]
       expect(groups).to match_array(result)
     end
+
+    it 'cost_benefit_per_video' do
+      groups = GoogleAds::View.new('spec/suports/report_adsense_sample.csv').cost_benefit_per_video
+      result = [
+        { id_video_principal: 'v1', cost_benefit: (((712 + (46.43 * 2) + (30.92 * 4) + (25.17 * 5) + (17.97 * 3))/15)/ 10.05).floor(2)},
+        { id_video_principal: 'v10', cost_benefit: (((595 + (29.519 * 2) + (17.27 * 4) + (10.07 * 5) + (5.5 * 3))/15)/ 6.96).floor(2)}
+      ]
+      expect(groups).to match_array(result)
+    end
+
   end
 end


### PR DESCRIPTION
@marcodotcastro 

- foi utilizado a seguinte logica, foi passado pesos para os parâmetros pelo cliente e com esses dados tempo uma media
   ((parâmetro * peso) + (parâmetro * peso) + ... ) / total de pesos, com essa media teríamos duas escolhas trabalhar com números muitos próximos de 0 (custo / media ) que nesse caso o quão menor for o numero melhor o custo beneficio ou o inverso (media / custo) que nesse caso quanto maior for o numero é melhor o custo beneficio, foi optado para essa primeira versão trabalhar com (media / custo) visando uma melhor experiência dos usuários funcionando como um score mesmo quanto mais alto melhor o investimento.

- foram criado dois métodos e foi modificado o método read principal (agora ele traz todas as informações do csv PS: foi necessário para o calculo do custo beneficio)
