### PR TITLE
Youtube video title validation issue #39

### DIFF
--- a/lib/growth_channel/util/manage_csv.rb
+++ b/lib/growth_channel/util/manage_csv.rb
@@ -10,10 +10,8 @@ class ManageCSV
                 if !row["Views"].match("[0-9]+")
                     raise ArgumentError.new('Tipo de dado incorreto, esperado: númerico.')  
                 end
-            end      
-            
-            return report
-        
+            end
+            self.validate_youtube_title(report)
         else 
             raise ArgumentError.new('É necessário que o CSV contenha os formatos: [Video title] e [Views]')
         end
@@ -33,6 +31,15 @@ class ManageCSV
         end
 
         return validate
+    end
+
+    def self.validate_youtube_title(report)
+        report["Video title"].each do |row|
+            unless row.match(/^[vV]\d*\.\d*\.?\d\:.+/)
+                return "#{row["Video title"]} não está em um formato correto!"
+            end
+        end
+        report
     end
 
 end


### PR DESCRIPTION
PR para avaliação refente a issue #39 

Adicionei um simples método que percorre os títulos e verifica se os mesmos estão no padrão requerido: vX.X:M ou vX.X.X:M, onde X é um número é M é uma descrição do vídeo.

Ainda preciso resolver alguns problemas, como por exemplo, adicionar mais testes para cobrir todo o código e etc. De acordo com seu parecer @marcodotcastro posso mudar a estrategia ou evoluir essa até chegar no PR definitivo.